### PR TITLE
Changes to allow spaced values in filter_expression_parser

### DIFF
--- a/lib/hpath/filter.rb
+++ b/lib/hpath/filter.rb
@@ -10,6 +10,7 @@ class Hpath::Filter
       [:and, []]
     else
       case string
+      when /!=/  then [:inequality, string.split("!=")]
       when /=/  then [:equality, string.split("=")]
       when /</  then [:less_than, string.split("<")]
       when />/  then [:greater_than, string.split(">")]
@@ -40,6 +41,13 @@ class Hpath::Filter
         object[key.to_s] == value.to_sym || object[key.to_sym] == value.to_sym
       elsif object.respond_to(key)
         object.send(key) == value
+      end
+    elsif @type == :inequality
+      key, value = @operands
+      if object.is_a?(Hash)
+       object[key.to_s] != value.to_s 
+      elsif object.respond_to(key)
+        object.send(key) != value
       end
     end
   end

--- a/lib/hpath/parser/filter_expression_parser.rb
+++ b/lib/hpath/parser/filter_expression_parser.rb
@@ -28,7 +28,7 @@ class Hpath::Parser::FilterExpressionParser
     current_filter = Hpath::Filter.new
     parent = {} # look up table    
     
-    string.gsub(/\s/, "").each_char do |char|
+    string.each_char do |char|
       unless special_character?(char)
         char_buffer << char
       else


### PR DESCRIPTION
The filter expression has been changed in order to consider spaced values. Furthermore, inequality feature is also added for simple string type matching alone.